### PR TITLE
Integrate jtlenzz's changes to printf.c for when vfctprintf is available

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -907,8 +907,13 @@ int fctprintf(void (*out)(char character, void* arg), void* arg, const char* for
 {
   va_list va;
   va_start(va, format);
-  const out_fct_wrap_type out_fct_wrap = { out, arg };
-  const int ret = _vsnprintf(_out_fct, (char*)(uintptr_t)&out_fct_wrap, (size_t)-1, format, va);
+  const int ret = fctvprintf(out, arg, format, va);
   va_end(va);
   return ret;
+}
+
+int fctvprintf(void (*out)(char character, void* arg), void* arg, const char * format, va_list va)
+{
+  const out_fct_wrap_type out_fct_wrap = { out, arg };
+  return _vsnprintf(_out_fct, (char*)(uintptr_t)&out_fct_wrap, (size_t)-1, format, va);
 }

--- a/printf.h
+++ b/printf.h
@@ -108,6 +108,16 @@ int vprintf_(const char* format, va_list va);
  */
 int fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...);
 
+/**
+ * vprintf with output function
+ * You may use this as dynamic alternative to vprintf() with its fixed _putchar() output
+ * \param out An output function which takes one character and an argument pointer
+ * \param arg An argument pointer for user data passed to output function
+ * \param format A string that specifies the format of the output
+ * \param va A value identifying a variable arguments list
+ * \return The number of characters that are sent to the output function, not counting the terminating null character
+ */
+int fctvprintf(void (*out)(char character, void* arg), void* arg, const char* format, va_list va);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I've already integrated an exposure of a `vfctprintf()` function, from @bart112233's repository (see [here](https://github.com/eyalroz/printf/pull/6)). But in that PR, we did not change the implementation of `fctprintf()` to utilize this new function - something which jtlenzz' repository does do.

I won't adopt the different naming though.