### PR TITLE
svkampen's addition of __attribute__((format)) decorations in `__GNUC__` compilers

### DIFF
--- a/printf.h
+++ b/printf.h
@@ -58,6 +58,9 @@ void _putchar(char character);
  * \return The number of characters that are written into the array, not counting the terminating null character
  */
 #define printf printf_
+#ifdef __GNUC__
+__attribute__ ((format (__printf__, 1, 2)))
+#endif
 int printf_(const char* format, ...);
 
 
@@ -69,6 +72,9 @@ int printf_(const char* format, ...);
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
 #define sprintf sprintf_
+#ifdef __GNUC__
+__attribute__ ((format (__printf__, 2, 3)))
+#endif
 int sprintf_(char* buffer, const char* format, ...);
 
 
@@ -84,7 +90,14 @@ int sprintf_(char* buffer, const char* format, ...);
  */
 #define snprintf  snprintf_
 #define vsnprintf vsnprintf_
+#ifdef __GNUC__
+__attribute__ ((format (__printf__, 3, 4)))
+#endif
 int  snprintf_(char* buffer, size_t count, const char* format, ...);
+
+#ifdef __GNUC__
+__attribute__ ((format (__printf__, 3, 0)))
+#endif
 int vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
 
 
@@ -95,6 +108,9 @@ int vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
 #define vprintf vprintf_
+#ifdef __GNUC__
+__attribute__ ((format (__printf__, 1, 0)))
+#endif
 int vprintf_(const char* format, va_list va);
 
 
@@ -106,6 +122,9 @@ int vprintf_(const char* format, va_list va);
  * \param format A string that specifies the format of the output
  * \return The number of characters that are sent to the output function, not counting the terminating null character
  */
+#ifdef __GNUC__
+__attribute__ ((format (__printf__, 3, 4)))
+#endif
 int fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...);
 
 


### PR DESCRIPTION
@svkampen says: "Using __attribute__((format)) means that compilers supporting the attribute (GCC, clang, icc, perhaps others) will automatically issue warnings when `printf()` arguments are incorrectly typed (i.e. inconsistent with the type specified in the format string)."