### PR TITLE
Fix wrong header install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ install(
 )
 
 install(
-	FILES "src/printf.h"
+	FILES "src/printf/printf.h"
 	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 


### PR DESCRIPTION
Running:

```
$ cmake --build . --target install
```

Results in an error:

    Consolidate compiler generated dependencies of target printf
    [100%] Built target printf
    Install the project...
    -- Install configuration: ""
    -- Installing: /home/kacper/Workspace/EyalrozPrintf/build/export/lib/libprintf.so
    CMake Error at cmake_install.cmake:65 (file):
      file INSTALL cannot find
      "/home/kacper/Workspace/EyalrozPrintf/src/printf.h": No such file or
      directory.

    make: *** [Makefile:83: install] Error 1

This PR fixes that.