### PR TITLE
Install printf.h under <prefix>/include/printf/printf.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ install(
 
 install(
 	FILES "src/printf/printf.h"
-	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/printf"
 )
 
 install(


### PR DESCRIPTION
The previous path was: `<prefix>/include/printf.h.` It was colliding with the `printf.h` from GNU C library:

https://github.com/lattera/glibc/blob/master/stdio-common/printf.h

An example which uses the printf.h from the GNU C library:
https://www.gnu.org/software/libc/manual/html_node/Printf-Extension-Example.html

Since this PR the installed library shall be utilized like that:

```
#include <printf/printf.h>
```