### PR TITLE
Adopt a uniform, convenient, output gadget for the implementation functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(
 	LANGUAGES C
 	DESCRIPTION "Self-contained C implementation of printf, vprintf, sprintf and related functions"
 	HOMEPAGE_URL https://github.com/eyalroz/printf
-	VERSION 5.3.0
+	VERSION 6.0.0
 )
 
 option(BUILD_TESTS          "Build test programs for the library" OFF)


### PR DESCRIPTION
See #32.

Now using a convenient uniform gadget for the inner implementation functions.

* Added: An `output_gadget_t` struct
* Added: Named constructor idioms for `output_gadget_t`, instead of the function wrappers we have before: For `putchar_()` output, buffer output, discarding/no output, and arbitrary function output.
* Implementation functions no longer need to maintain and pass around the parameters `buffer`, `maxlen`, `idx` - these are part of the uniform output gadget
* Implementation functions no longer need to increase the position within the output (`idx)`, nor return the increased value to their caller.
* No longer need a dummy buffer of size 1, anywhere.