### PR TITLE
Remove conditionals to include limits.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CheckTypeSize)
 project(
 	printf
 	LANGUAGES C
-	DESCRIPTION "Mostly-stand-alone C implementation of printf, vprintf, sprintf and related functions"
+	DESCRIPTION "Self-contained C implementation of printf, vprintf, sprintf and related functions"
 	HOMEPAGE_URL https://github.com/eyalroz/printf
 	VERSION 5.3.0
 )

--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -950,14 +950,28 @@ process_integral_specifier(out_fct_type out, char *buffer, printf_size_t maxlen,
   return idx;
 }
 
+// Advances the format pointer past the flags, and returns the parsed flags
+// due to the characters passed
+printf_flags_t parse_flags(const char** format)
+{
+  printf_flags_t flags = 0U;
+  do {
+    switch (**format) {
+      case '0': flags |= FLAGS_ZEROPAD; (*format)++; break;
+      case '-': flags |= FLAGS_LEFT;    (*format)++; break;
+      case '+': flags |= FLAGS_PLUS;    (*format)++; break;
+      case ' ': flags |= FLAGS_SPACE;   (*format)++; break;
+      case '#': flags |= FLAGS_HASH;    (*format)++; break;
+      default : return flags;
+    }
+  } while (true);
+}
 
 // internal vsnprintf - used for implementing _all library functions
 // Note: We don't like the C standard's parameter names, so using more informative parameter names
 // here instead.
 static int _vsnprintf(out_fct_type out, char* buffer, printf_size_t buffer_size, const char* format, va_list args)
 {
-  printf_flags_t flags;
-  printf_size_t width, precision, n;
   printf_size_t idx = 0U;
 
   if (!buffer) {
@@ -979,21 +993,10 @@ static int _vsnprintf(out_fct_type out, char* buffer, printf_size_t buffer_size,
       format++;
     }
 
-    // evaluate flags
-    flags = 0U;
-    do {
-      switch (*format) {
-        case '0': flags |= FLAGS_ZEROPAD; format++; n = 1U; break;
-        case '-': flags |= FLAGS_LEFT;    format++; n = 1U; break;
-        case '+': flags |= FLAGS_PLUS;    format++; n = 1U; break;
-        case ' ': flags |= FLAGS_SPACE;   format++; n = 1U; break;
-        case '#': flags |= FLAGS_HASH;    format++; n = 1U; break;
-        default :                                   n = 0U; break;
-      }
-    } while (n);
+    printf_flags_t flags = parse_flags(&format);
 
     // evaluate width field
-    width = 0U;
+    printf_size_t width = 0U;
     if (is_digit_(*format)) {
       width = (printf_size_t) atou_(&format);
     }
@@ -1010,7 +1013,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, printf_size_t buffer_size,
     }
 
     // evaluate precision field
-    precision = 0U;
+    printf_size_t precision = 0U;
     if (*format == '.') {
       flags |= FLAGS_PRECISION;
       format++;

--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -38,16 +38,12 @@
 
 #ifdef __cplusplus
 #include <cstdint>
-#ifdef PRINTF_SUPPORT_MSVC_STYLE_INTEGER_SPECIFIERS
 #include <climits>
-#endif
 extern "C" {
 #else
 #include <stdbool.h>
 #include <stdint.h>
-#ifdef PRINTF_SUPPORT_MSVC_STYLE_INTEGER_SPECIFIERS
 #include <limits.h>
-#endif
 #endif // __cplusplus
 
 // Define this globally (e.g. gcc -DPRINTF_INCLUDE_CONFIG_H ...) to include the

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -822,6 +822,15 @@ TEST_CASE("float", "[]" ) {
   PRINTING_CHECK("3.1415",    ==, sprintf_, buffer, "%.4f", 3.1415354);
   PRINTING_CHECK("30343.142", ==, sprintf_, buffer, "%.3f", 30343.1415354);
 
+  PRINTING_CHECK("2.1474836470e+09", ==, sprintf_, buffer, "%.10f", 2147483647.0); // 2^31 - 1
+  PRINTING_CHECK("2.1474836480e+09", ==, sprintf_, buffer, "%.10f", 2147483648.0); // 2^31
+  PRINTING_CHECK("4.2949672950e+09", ==, sprintf_, buffer, "%.10f", 4294967295.0); // 2^32 - 1
+  PRINTING_CHECK("4.2949672960e+09", ==, sprintf_, buffer, "%.10f", 4294967296.0); // 2^32
+  PRINTING_CHECK("2147483647", ==, sprintf_, buffer, "%.10g", 2147483647.0); // 2^31 - 1
+  PRINTING_CHECK("2147483648", ==, sprintf_, buffer, "%.10g", 2147483648.0); // 2^31
+  PRINTING_CHECK("4294967295", ==, sprintf_, buffer, "%.10g", 4294967295.0); // 2^32 - 1
+  PRINTING_CHECK("4294967296", ==, sprintf_, buffer, "%.10g", 4294967296.0); // 2^32
+
   // switch from decimal to exponential representation
   //
   CAPTURE_AND_PRINT(sprintf_, buffer, "%.0f", (double) ((int64_t)1 * 1000 ) );


### PR DESCRIPTION
INT_MAX and other values from limits.h are used even in conditions where limits.h is included. Those conditions are removed here.

Fixes #95 