### PR TITLE
Remove duplicated non-standard test, and increase disabled warnings for same test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CheckTypeSize)
 project(
 	printf
 	LANGUAGES C
-	DESCRIPTION "Mostly-stand-alone C implementation of printf, vprintf, sprintf and related functions"
+	DESCRIPTION "Self-contained C implementation of printf, vprintf, sprintf and related functions"
 	HOMEPAGE_URL https://github.com/eyalroz/printf
 	VERSION 5.3.0
 )

--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -950,14 +950,28 @@ process_integral_specifier(out_fct_type out, char *buffer, printf_size_t maxlen,
   return idx;
 }
 
+// Advances the format pointer past the flags, and returns the parsed flags
+// due to the characters passed
+printf_flags_t parse_flags(const char** format)
+{
+  printf_flags_t flags = 0U;
+  do {
+    switch (**format) {
+      case '0': flags |= FLAGS_ZEROPAD; (*format)++; break;
+      case '-': flags |= FLAGS_LEFT;    (*format)++; break;
+      case '+': flags |= FLAGS_PLUS;    (*format)++; break;
+      case ' ': flags |= FLAGS_SPACE;   (*format)++; break;
+      case '#': flags |= FLAGS_HASH;    (*format)++; break;
+      default : return flags;
+    }
+  } while (true);
+}
 
 // internal vsnprintf - used for implementing _all library functions
 // Note: We don't like the C standard's parameter names, so using more informative parameter names
 // here instead.
 static int _vsnprintf(out_fct_type out, char* buffer, printf_size_t buffer_size, const char* format, va_list args)
 {
-  printf_flags_t flags;
-  printf_size_t width, precision, n;
   printf_size_t idx = 0U;
 
   if (!buffer) {
@@ -979,21 +993,10 @@ static int _vsnprintf(out_fct_type out, char* buffer, printf_size_t buffer_size,
       format++;
     }
 
-    // evaluate flags
-    flags = 0U;
-    do {
-      switch (*format) {
-        case '0': flags |= FLAGS_ZEROPAD; format++; n = 1U; break;
-        case '-': flags |= FLAGS_LEFT;    format++; n = 1U; break;
-        case '+': flags |= FLAGS_PLUS;    format++; n = 1U; break;
-        case ' ': flags |= FLAGS_SPACE;   format++; n = 1U; break;
-        case '#': flags |= FLAGS_HASH;    format++; n = 1U; break;
-        default :                                   n = 0U; break;
-      }
-    } while (n);
+    printf_flags_t flags = parse_flags(&format);
 
     // evaluate width field
-    width = 0U;
+    printf_size_t width = 0U;
     if (is_digit_(*format)) {
       width = (printf_size_t) atou_(&format);
     }
@@ -1010,7 +1013,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, printf_size_t buffer_size,
     }
 
     // evaluate precision field
-    precision = 0U;
+    printf_size_t precision = 0U;
     if (*format == '.') {
       flags |= FLAGS_PRECISION;
       format++;

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -822,6 +822,15 @@ TEST_CASE("float", "[]" ) {
   PRINTING_CHECK("3.1415",    ==, sprintf_, buffer, "%.4f", 3.1415354);
   PRINTING_CHECK("30343.142", ==, sprintf_, buffer, "%.3f", 30343.1415354);
 
+  PRINTING_CHECK("2.1474836470e+09", ==, sprintf_, buffer, "%.10f", 2147483647.0); // 2^31 - 1
+  PRINTING_CHECK("2.1474836480e+09", ==, sprintf_, buffer, "%.10f", 2147483648.0); // 2^31
+  PRINTING_CHECK("4.2949672950e+09", ==, sprintf_, buffer, "%.10f", 4294967295.0); // 2^32 - 1
+  PRINTING_CHECK("4.2949672960e+09", ==, sprintf_, buffer, "%.10f", 4294967296.0); // 2^32
+  PRINTING_CHECK("2147483647", ==, sprintf_, buffer, "%.10g", 2147483647.0); // 2^31 - 1
+  PRINTING_CHECK("2147483648", ==, sprintf_, buffer, "%.10g", 2147483648.0); // 2^31
+  PRINTING_CHECK("4294967295", ==, sprintf_, buffer, "%.10g", 4294967295.0); // 2^32 - 1
+  PRINTING_CHECK("4294967296", ==, sprintf_, buffer, "%.10g", 4294967296.0); // 2^32
+
   // switch from decimal to exponential representation
   //
   CAPTURE_AND_PRINT(sprintf_, buffer, "%.0f", (double) ((int64_t)1 * 1000 ) );

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -83,6 +83,7 @@ do {                                                             \
     #define DISABLE_WARNING_PRINTF_FORMAT
     #define DISABLE_WARNING_PRINTF_FORMAT_EXTRA_ARGS
     #define DISABLE_WARNING_PRINTF_FORMAT_OVERFLOW
+    #define DISABLE_WARNING_PRINTF_FORMAT_INVALID_SPECIFIER
 
 #elif defined(__GNUC__) || defined(__clang__)
     #define DO_PRAGMA(X) _Pragma(#X)
@@ -94,20 +95,24 @@ do {                                                             \
     #define DISABLE_WARNING_PRINTF_FORMAT_EXTRA_ARGS DISABLE_WARNING(-Wformat-extra-args)
 #if defined(__clang__)
     #define DISABLE_WARNING_PRINTF_FORMAT_OVERFLOW
+    #define DISABLE_WARNING_PRINTF_FORMAT_INVALID_SPECIFIER DISABLE_WARNING(-Wformat-invalid-specifier)
 #else
     #define DISABLE_WARNING_PRINTF_FORMAT_OVERFLOW DISABLE_WARNING(-Wformat-overflow)
+    #define DISABLE_WARNING_PRINTF_FORMAT_INVALID_SPECIFIER
 #endif
 #else
     #define DISABLE_WARNING_PUSH
     #define DISABLE_WARNING_POP
     #define DISABLE_WARNING_PRINTF_FORMAT
     #define DISABLE_WARNING_PRINTF_FORMAT_EXTRA_ARGS
+    #define DISABLE_WARNING_PRINTF_FORMAT_INVALID_SPECIFIER
 #endif
 
 #ifdef TEST_WITH_NON_STANDARD_FORMAT_STRINGS
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_PRINTF_FORMAT
 DISABLE_WARNING_PRINTF_FORMAT_EXTRA_ARGS
+DISABLE_WARNING_PRINTF_FORMAT_INVALID_SPECIFIER
 #endif
 
 #if defined(_MSC_VER)
@@ -1073,7 +1078,6 @@ TEST_CASE("string length", "[]" ) {
   PRINTING_CHECK("123", ==, sprintf_, buffer, "%.7s", "123");
   PRINTING_CHECK("", ==, sprintf_, buffer, "%.7s", "");
   PRINTING_CHECK("1234ab", ==, sprintf_, buffer, "%.4s%.2s", "123456", "abcdef");
-  PRINTING_CHECK(".2s", ==, sprintf_, buffer, "%.4.2s", "123456");
   PRINTING_CHECK("123", ==, sprintf_, buffer, "%.*s", 3, "123456");
 
 DISABLE_WARNING_PUSH
@@ -1087,6 +1091,8 @@ TEST_CASE("string length (non-standard format)", "[]" ) {
   char buffer[100];
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_PRINTF_FORMAT
+DISABLE_WARNING_PRINTF_FORMAT_EXTRA_ARGS
+DISABLE_WARNING_PRINTF_FORMAT_INVALID_SPECIFIER
   PRINTING_CHECK(".2s", ==, sprintf_, buffer, "%.4.2s", "123456");
 DISABLE_WARNING_POP
 }


### PR DESCRIPTION
One invalid test was duplicated, so I removed the implementatino outside of the TEST_WITH_NON_STANDARD_FORMAT_STRINGS block.

Within that block, I disabled two other warnings (one which needed a new pragma definition), because Clang shows one and GCC shows the other in my setup.