### PR TITLE
Adopt Inva Vnucec's github actions CI workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,48 @@
+name: Build and test
+
+on: [workflow_dispatch, push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        os: [ubuntu-20.04] # TODO: add: windows-latest, macos-latest
+
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+        
+      - name: Install dependencies on Ubuntu
+        if: matrix.os == 'ubuntu-20.04'
+        run: |
+          sudo apt update
+          sudo apt-get install -y gcc python3-pip
+          pip3 install gcovr
+
+      - name: Install dependencies on mac-os
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install gcc python3
+          pip3 install gcovr
+
+      - name: Build project
+        run: make
+
+      - name: Test project
+        run: ./bin/test_suite -d yes
+
+      - name: Generate Code coverage report
+        run: |
+          ./tmp/cov/test_suite
+          gcovr -r . -e test --html -o codecov_report.html
+        
+      - name: Upload code coverage report as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: codecov_report
+          path: codecov_report.html
+        
+      - name: Upload code coverage reports to codecov.io page
+        run: bash <(curl -s https://codecov.io/bash) 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ syntax: glob
 # Files which "ask" to be hidden
 *~
 .*
+!.github
 unused/
 
 # Build artifacts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Standalone printf/sprintf formatted printing function library
 
+[![Build and test](https://github.com/eyalroz/printf/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/eyalroz/printf/actions/workflows/build_and_test.yml)
+[![codecov](https://codecov.io/gh/eyalroz/printf/branch/master/graph/badge.svg)](https://codecov.io/gh/eyalroz/printf)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/eyalroz/printf/master/LICENSE)
 [![Github Bug-type issues](https://shields.io/github/issues-search/eyalroz/printf?query=is:open%20is:issue%20label:bug&label=open%20bugs)](http://github.com/eyalroz/printf/issues)
 <sup>Parent repository: </sup>[![Github issues (original repo)](https://img.shields.io/github/issues/mpaland/printf.svg)](http://github.com/mpaland/printf/issues)
@@ -254,4 +256,3 @@ I try to attend to issues and PRs promptly.
 ## License
 
 This library is published under the terms of the [MIT license](http://www.opensource.org/licenses/MIT).
-


### PR DESCRIPTION
- Create GitHub Actions config file
- Fix GH Actions badge in README file
- Add gcovr code coverage html report
- (exclude mac os because building is not yet supported on mac)