### PR TITLE
Wrap configuration header include in test_suite.cpp with #if

### DIFF
--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -47,7 +47,7 @@ extern "C" {
 #include <limits.h>
 #endif // __cplusplus
 
-// Define this globally (e.g. gcc -DPRINTF_INCLUDE_CONFIG_H ...) to include the
+// Define this globally (e.g. gcc -DPRINTF_INCLUDE_CONFIG_H=1 ...) to include the
 // printf_config.h header file
 #if PRINTF_INCLUDE_CONFIG_H
 #include "printf_config.h"

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -29,7 +29,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #define PRINTF_VISIBILITY static
+#if PRINTF_INCLUDE_CONFIG_H
 #include <printf_config.h>
+#endif
 #include <printf/printf.c>
 
 // use the 'catch' test framework


### PR DESCRIPTION
The test suite can successfully build and run without the configuration header. Its inclusion should be treated similarly to its use in printf.c