### PR TITLE
fixes and improvement for mingw on msys2 env

### DIFF
--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -1027,12 +1027,12 @@ static printf_flags_t parse_flags(const char** format)
   } while (true);
 }
 
-// internal vsnprintf - used for implementing _all library functions
+// internal_vsnprintf - used for implementing _all library functions
 // Note: We don't like the C standard's parameter names, so using more informative parameter names
 // here instead.
-static int _vsnprintf(output_gadget_t* output, const char* format, va_list args)
+static int internal_vsnprintf(output_gadget_t* output, const char* format, va_list args)
 {
-  // Note: The library only calls _vsnprintf() with output->pos being 0. However, it is
+  // Note: The library only calls internal_vsnprintf() with output->pos being 0. However, it is
   // possible to call this function with a non-zero pos value for some "remedial printing".
 
   while (*format)
@@ -1353,13 +1353,13 @@ static int _vsnprintf(output_gadget_t* output, const char* format, va_list args)
 int vprintf_(const char* format, va_list arg)
 {
   output_gadget_t gadget = extern_putchar_gadget();
-  return _vsnprintf(&gadget, format, arg);
+  return internal_vsnprintf(&gadget, format, arg);
 }
 
 int vsnprintf_(char* s, size_t n, const char* format, va_list arg)
 {
   output_gadget_t gadget = buffer_gadget(s, n);
-  return _vsnprintf(&gadget, format, arg);
+  return internal_vsnprintf(&gadget, format, arg);
 }
 
 int vsprintf_(char* s, const char* format, va_list arg)
@@ -1370,7 +1370,7 @@ int vsprintf_(char* s, const char* format, va_list arg)
 int vfctprintf(void (*out)(char c, void* extra_arg), void* extra_arg, const char* format, va_list arg)
 {
   output_gadget_t gadget = function_gadget(out, extra_arg);
-  return _vsnprintf(&gadget, format, arg);
+  return internal_vsnprintf(&gadget, format, arg);
 }
 
 int printf_(const char* format, ...)

--- a/src/printf/printf.h
+++ b/src/printf/printf.h
@@ -49,8 +49,17 @@ extern "C" {
 #endif
 
 #ifdef __GNUC__
+// if the compiler supports the 'gnu_printf' format it is prefered over the generic 'printf'
+// format specifier, because on mingw the compiler is defaulting to the microsoft dialect
+// 'ms_printf' for the generic format specifier variant. This would lead to false warnings
+// when using "%zu" for example.
+# if ((__GNUC__ == 4 && __GNUC_MINOR__>= 4) || __GNUC__ > 4)
 # define ATTR_PRINTF(one_based_format_index, first_arg) \
-__attribute__((format(__printf__, (one_based_format_index), (first_arg))))
+__attribute__((format(gnu_printf, (one_based_format_index), (first_arg))))
+# else
+# define ATTR_PRINTF(one_based_format_index, first_arg) \
+__attribute__((format(printf, (one_based_format_index), (first_arg))))
+# endif
 # define ATTR_VPRINTF(one_based_format_index) ATTR_PRINTF((one_based_format_index), 0)
 #else
 # define ATTR_PRINTF((one_based_format_index), (first_arg))

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -44,11 +44,11 @@
 #include <iostream>
 #include <iomanip>
 
-#if defined(_WIN32)
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__)) || defined(__MINGW32__)
+#include <sys/types.h>
+#elif defined(_WIN32)
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
-#elif defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
-#include <sys/types.h>
 #else
 // Let's just cross our fingers and hope `ssize_t` is defined.
 #endif


### PR DESCRIPTION
fixes the following issues for mingw on msys2:

- `__attribute__((format(printf ...` assumes the microsoft dialekt on mingw, which leads to false positive warnings when "%zu" is used for example
- the `_vsnprintf ` function name colides with a definition in stdio.h of mingw -> so compiling tests fails. 