### PR TITLE
Fixing variable that may be unitialized at use

### DIFF
--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -861,7 +861,7 @@ static void print_exponential_number(output_gadget_t* output, double number, pri
   double abs_number =  negative ? -number : number;
 
   int floored_exp10;
-  bool abs_exp10_covered_by_powers_table;
+  bool abs_exp10_covered_by_powers_table = false;
   struct scaling_factor normalization;
 
 


### PR DESCRIPTION
In line 908: `normalization.multiply = (floored_exp10 < 0 && abs_exp10_covered_by_powers_table);`, `abs_exp10_covered_by_powers_table` may be uninitialized. Setting it to false originally. 