### PR TITLE
Enable %u8/u16/u32/u64 and similar if PRINTF_SUPPORT_HUMAN_STYLE_SPECIFIERS is defined

### DIFF
--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -163,7 +163,7 @@
 #define FLAGS_SIGNED    (1U << 14U)
   // Only used with PRINTF_SUPPORT_MSVC_STYLE_INTEGER_SPECIFIERS
 
-#ifdef PRINTF_SUPPORT_MSVC_STYLE_INTEGER_SPECIFIERS
+#if (PRINTF_SUPPORT_MSVC_STYLE_INTEGER_SPECIFIERS || PRINTF_SUPPORT_HUMAN_STYLE_SPECIFIERS)
 
 #define FLAGS_INT8 FLAGS_CHAR
 
@@ -204,7 +204,7 @@
 #error "No basic integer type has a size of 64 bits exactly"
 #endif
 
-#endif // PRINTF_SUPPORT_MSVC_STYLE_INTEGER_SPECIFIERS
+#endif // PRINTF_SUPPORT_MSVC_STYLE_INTEGER_SPECIFIERS || PRINTF_SUPPORT_HUMAN_STYLE_SPECIFIERS
 
 
 typedef unsigned int printf_flags_t;
@@ -1219,6 +1219,28 @@ static inline void format_string_loop(output_gadget_t* output, const char* forma
         }
 
         format++;
+#if PRINTF_SUPPORT_HUMAN_STYLE_SPECIFIERS
+        if ((flags & (FLAGS_LONG_LONG | FLAGS_LONG | FLAGS_SHORT | FLAGS_CHAR)) == 0) {
+          const char* format_next = format + 1;
+          switch(*format) {
+            case '8':
+              flags |= FLAGS_INT8;
+              format = format_next;
+              break;
+            case '1':
+              if (*format_next == '6') { format = format_next + 1; flags |= FLAGS_INT16; }
+              break;
+            case '3':
+              if (*format_next == '2') { format = format_next + 1; flags |= FLAGS_INT32; }
+              break;
+            case '6':
+              if (*format_next == '4') { format = format_next + 1; flags |= FLAGS_INT64; }
+              break;
+            default:
+              break;
+          }
+        }
+#endif
         // ignore '0' flag when precision is given
         if (flags & FLAGS_PRECISION) {
           flags &= ~FLAGS_ZEROPAD;


### PR DESCRIPTION
Enable %u8/u16/u32/u64 and similar human-friendly fixed-size specifiers (like %d/x) are enabled if PRINTF_SUPPORT_HUMAN_STYLE_SPECIFIERS is defined.

That's super handy if types similar to Linux kernel's s8/u8/s16/u16/s32/u32/s64/u64 are in use and MS-specific specifiers like %I32d are not available.

Adding custom specifiers is basically vendor lock and in general should be avoided but in case of printing fixed-size ints it brings more value than harm - I'm super happy to stop doing `%" PRIu64 "` - just `%u64` is much easier to remember and use.

Of course MS-specific specifiers could be used for similar goals but I think this library deserves its own cross-platform specifiers which are even better (shorter and easier to remember) than those from MS CRT.

That's my small attempt to thank all contributors for developing such great library.