### PR TITLE
Add printf-config.cmake installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,12 @@ install(
 
 include(CMakePackageConfigHelpers)
 
+configure_package_config_file(
+	"printf-config.cmake.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/printf-config.cmake"
+	INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/printf"
+)
+
 write_basic_package_version_file(
 	"printf-config-version.cmake"
 	VERSION ${PROJECT_VERSION}
@@ -193,5 +199,6 @@ write_basic_package_version_file(
 
 install(
 	FILES "${CMAKE_CURRENT_BINARY_DIR}/printf-config-version.cmake"
+		  "${CMAKE_CURRENT_BINARY_DIR}/printf-config.cmake"
 	DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/printf"
 )

--- a/printf-config.cmake.in
+++ b/printf-config.cmake.in
@@ -1,0 +1,5 @@
+get_filename_component(PRINTF_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+if(NOT TARGET printf::printf)
+  include("${PRINTF_CMAKE_DIR}/printf-targets.cmake")
+endif()


### PR DESCRIPTION
After library installation if you try find_package(printf) in another project you got CMake error like bellow:
> Could not find a package configuration file provided by "printf" with any
> of the following names:
>
>   printfConfig.cmake
>   printf-config.cmake

This commit adds simplest printf-config.cmake into installation bundle.