### PR TITLE
autotest: fix getopt parsing

### DIFF
--- a/test/autotest.cpp
+++ b/test/autotest.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
 
 static bool parse_options(int argc, char *argv[])
 {
-  char c;
+  int c;
   bool gotopt = false;
 
   opts.i = false;


### PR DESCRIPTION
`getopt` returns an `int` and truncating it to a `char` causes issues on my system
https://man7.org/linux/man-pages/man3/getopt.3.html