### PR TITLE
Remove remaining double operations

### DIFF
--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -883,8 +883,8 @@ static floating_point_t pow10_of_int(int floored_exp10)
   }
   // Compute 10^(floored_exp10) but (try to) make sure that doesn't overflow
   floating_point_with_bit_access dwba;
-  int exp2 = bastardized_floor((floating_point_t) (floored_exp10 * 3.321928094887362 + 0.5));
-  const floating_point_t z  = (floating_point_t) (floored_exp10 * 2.302585092994046 - exp2 * 0.6931471805599453);
+  int exp2 = bastardized_floor(floored_exp10 * (floating_point_t) 3.321928094887362 + (floating_point_t) 0.5);
+  const floating_point_t z  = floored_exp10 * (floating_point_t) 2.302585092994046 - exp2 * (floating_point_t) 0.6931471805599453;
   const floating_point_t z2 = z * z;
   dwba.U = ((printf_fp_uint_t)(exp2) + FP_TYPE_BASE_EXPONENT) << FP_TYPE_STORED_MANTISSA_BITS;
   // compute exp(z) using continued fractions,


### PR DESCRIPTION
Followup to #84 / 25bd5dfe387142713ded5bd877aea907f57d99b4.

The `PRINTF_USE_DOUBLE_INTERNALLY` macro can be used to select whether the library uses `double` or `float` types for internal floating-point calculations. However, there still exist a few expressions that contain uncasted floating point literals, resulting in `double`-typed literals and thus `double`-precision operations. Cast these literals to `floating_point_t` to remove remaining `double` operations when using `float`s internally.

Tested in an embedded environment that prohibits `double`s (Except for `f2d` and `d2f`, for passing `float`s through the varargs).

All unit tests pass.