### PR TITLE
Added support for PRINTF_NO_STACK_BUFFER #226.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Options used both in CMake and in the library source code via a preprocessor def
 | SUPPORT_WRITEBACK_SPECIFIER            | YES     |  Support the length write-back specifier (%n) |
 | SUPPORT_LONG_LONG                      | YES     |  Support long long integral types (allows for the ll length modifier and affects %p) |
 | USE_DOUBLE_INTERNALLY                  | YES     |  Use the `double` for internal floating-point calculations (rather than using the single-precision `float` type |
+| NO_STACK_BUFFER						 | NO	   |  Define buffers as static |
 
 In the source files themselves, these options become preprocessor definitions with a `PRINTF_` prefix; the boolean ones have value `1` OR `0` for YES or NO respectively; and the aliasing option translates into one of three definitions: `ALIAS_STANDARD_FUNCTION_NAMES_NONE`, `ALIAS_STANDARD_FUNCTION_NAMES_SOFT` or `ALIAS_STANDARD_FUNCTION_NAMES_HARD`.
 

--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -614,7 +614,11 @@ static void print_integer_finalization(output_gadget_t* output, char* buf, print
 /* An internal itoa-like function */
 static void print_integer(output_gadget_t* output, printf_unsigned_value_t value, bool negative, numeric_base_t base, printf_size_t precision, printf_size_t width, printf_flags_t flags)
 {
+  #ifdef PRINTF_NO_STACK_BUFFER
+  static char buf[PRINTF_INTEGER_BUFFER_SIZE] = { 0 };
+  #else
   char buf[PRINTF_INTEGER_BUFFER_SIZE];
+  #endif // PRINTF_NO_STACK_BUFFER
   printf_size_t len = 0U;
 
   if (!value) {
@@ -1156,7 +1160,11 @@ static void print_exponential_number(output_gadget_t* output, floating_point_t n
 
 static void print_floating_point(output_gadget_t* output, floating_point_t value, printf_size_t precision, printf_size_t width, printf_flags_t flags, bool prefer_exponential)
 {
+  #ifdef PRINTF_NO_STACK_BUFFER
+  static char buf[PRINTF_DECIMAL_BUFFER_SIZE] = { 0 };
+  #else
   char buf[PRINTF_DECIMAL_BUFFER_SIZE];
+  #endif // PRINTF_NO_STACK_BUFFER
   printf_size_t len = 0U;
 
   /* test for special values */


### PR DESCRIPTION
From issue #226.
If `PRINTF_NO_STACK_BUFFER` is defined during compile, `buf` from `print_integer` and `print_floating_point` is defined as static and thus moved from stack.